### PR TITLE
 Fixed version conflict with dart 2.1.0/flutter 0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   args: ">=0.10.0 <0.14.0"
   logging: ">=0.9.0 <0.12.0"
 environment:
-  sdk: '>=2.0.0-dev.68.0 <3.0.0'
+  sdk: ">=2.0.0-dev.68.0 <3.0.0"
 dev_dependencies:
   coverage: "^0.7.2"
   test: "^0.12.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   args: ">=0.10.0 <0.14.0"
   logging: ">=0.9.0 <0.12.0"
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.0.0-dev.58.0 <3.0.0"
 dev_dependencies:
   coverage: "^0.7.2"
   test: "^0.12.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,8 @@ homepage: https://github.com/codecov/dart
 dependencies:
   args: ">=0.10.0 <0.14.0"
   logging: ">=0.9.0 <0.12.0"
+environment:
+  sdk: '>=2.0.0-dev.68.0 <3.0.0'
 dev_dependencies:
   coverage: "^0.7.2"
   test: "^0.12.0"


### PR DESCRIPTION
Check https://github.com/flutter/flutter/issues/20700 for more info.

Issue is resolved by just setting a minimum environment version for the
plugin.